### PR TITLE
feat: UI polish - smaller social icons, find out more button, button cleanup

### DIFF
--- a/src/components/about/AboutMeBlurb.tsx
+++ b/src/components/about/AboutMeBlurb.tsx
@@ -116,10 +116,7 @@ const AboutMeBlurb = () => {
       </Text>
 
       <Center my={32}>
-        <MediumSubscribeButton
-          buttomText="Subscribe on Medium"
-          buttonWidth={'auto'}
-        />
+        <MediumSubscribeButton buttomText="Subscribe on Medium" />
       </Center>
     </Box>
   );

--- a/src/components/common/buttons/MediumCtaButton.tsx
+++ b/src/components/common/buttons/MediumCtaButton.tsx
@@ -1,20 +1,14 @@
-import { Button } from '@mantine/core';
 import { MediumLogo } from 'assets/icons/MediumLogo';
+import { RollingButton } from './RollingButton';
 
 export const MediumCtaButton = ({ mediumUrl }: { mediumUrl: string }) => {
   return (
-    <Button
-      variant="filled"
-      component="a"
-      size="lg"
+    <RollingButton
+      label="Read This Article on Medium"
       href={mediumUrl}
-      target="_blank"
-      leftSection={<MediumLogo size={25} />}
-      color="dark"
-      style={{ fontWeight: 500 }}
-      radius="md"
-    >
-      Read This Article on Medium
-    </Button>
+      external
+      icon={<MediumLogo size={20} />}
+      size="lg"
+    />
   );
 };

--- a/src/components/common/buttons/MediumSubscribeButton.tsx
+++ b/src/components/common/buttons/MediumSubscribeButton.tsx
@@ -1,28 +1,18 @@
-import { Button } from '@mantine/core';
 import { MediumLogo } from 'assets/icons/MediumLogo';
 import { MEDIUM_SUBSCRIBE_URL } from 'constants/constants';
+import { RollingButton } from './RollingButton';
 
 export const MediumSubscribeButton = ({
   buttomText = 'Medium',
-  buttonWidth = 200,
 }: {
   buttomText?: string;
-  buttonWidth?: number | 'auto';
 }) => {
   return (
-    <Button
-      variant="filled"
-      component="a"
-      size="lg"
+    <RollingButton
+      label={buttomText}
       href={MEDIUM_SUBSCRIBE_URL}
-      target="_blank"
-      leftSection={<MediumLogo size={25} />}
-      color="dark"
-      style={{ fontWeight: 500 }}
-      radius="md"
-      w={buttonWidth}
-    >
-      {buttomText}
-    </Button>
+      external
+      icon={<MediumLogo size={20} />}
+    />
   );
 };

--- a/src/components/hireMe/ExperienceTimeline.tsx
+++ b/src/components/hireMe/ExperienceTimeline.tsx
@@ -7,7 +7,7 @@ import { experienceData } from './data/experienceData';
 
 export const ExperienceTimeline: React.FC = () => {
   return (
-    <Box my={40}>
+    <Box id="experience" my={40}>
       <Title order={2} mb={24}>
         Experience
       </Title>

--- a/src/components/skillsBanner/SkillsBanner.tsx
+++ b/src/components/skillsBanner/SkillsBanner.tsx
@@ -1,10 +1,20 @@
-import React, { useEffect, useState } from 'react';
-import { Grid, useMantineTheme } from '@mantine/core';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Grid } from '@mantine/core';
+import { motion } from 'framer-motion';
 import { Skill, skillsData } from './data/skillsData';
 import { SkillCard } from './SkillCard';
 
 export const SkillsBanner = () => {
   const [modSkills, setModSkills] = useState<Skill[]>([]);
+
+  const twinkleVariants = useMemo(
+    () =>
+      skillsData.map(() => ({
+        duration: 2 + Math.random() * 3,
+        delay: Math.random() * 3,
+      })),
+    []
+  );
 
   useEffect(() => {
     if (skillsData?.length === 0) {
@@ -19,9 +29,19 @@ export const SkillsBanner = () => {
 
   return (
     <Grid grow gutter={'lg'} w="100%">
-      {modSkills?.map(skill => (
+      {modSkills?.map((skill, i) => (
         <Grid.Col key={skill.id} span={2}>
-          <SkillCard skill={skill} />
+          <motion.div
+            animate={{ opacity: [0.3, 1, 0.3] }}
+            transition={{
+              duration: twinkleVariants[i].duration,
+              repeat: Infinity,
+              ease: 'easeInOut',
+              delay: twinkleVariants[i].delay,
+            }}
+          >
+            <SkillCard skill={skill} />
+          </motion.div>
         </Grid.Col>
       ))}
     </Grid>

--- a/src/components/skillsBanner/SkillsBannerContainer.tsx
+++ b/src/components/skillsBanner/SkillsBannerContainer.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Flex, Title } from '@mantine/core';
 import { SkillsBanner } from './SkillsBanner';
+import { RollingButton } from 'components/common/buttons/RollingButton';
+import { HIRE_ME_ROUTE } from 'constants/routeConstants';
 
 export const SkillsBannerContainer = () => {
   return (
@@ -9,6 +11,10 @@ export const SkillsBannerContainer = () => {
         Technical Skills & Tools
       </Title>
       <SkillsBanner />
+      <RollingButton
+        label="Find out more"
+        href={`${HIRE_ME_ROUTE}#experience`}
+      />
     </Flex>
   );
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -198,9 +198,9 @@ a:hover {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
-  margin: 0 10px;
+  width: 42px;
+  height: 42px;
+  margin: 0 6px;
   border-radius: 50%;
   background-color: var(--mantine-color-myColor-2);
   color: var(--mantine-color-myColor-9);


### PR DESCRIPTION
## Summary
- Shrink social media icons (48→42px) and tighten spacing (10→6px margin) so they fit on one line in the mobile nav drawer
- Add anchor `id="experience"` to the hire-me ExperienceTimeline and a "Find out more" RollingButton on the homepage skills section linking to it
- Clean up MediumCtaButton and MediumSubscribeButton to use RollingButton instead of inline styled anchors

## Test plan
- [ ] Open mobile nav drawer — verify all 4 social icons fit on one line
- [ ] Visit homepage — verify "Find out more" button appears below skills banner
- [ ] Click "Find out more" — verify it navigates to `/hire-me#experience` and scrolls to the experience section
- [ ] Check Medium CTA and Subscribe buttons still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)