### PR TITLE
feat: custom loading screen and animated runner loader

### DIFF
--- a/src/components/blog/BlogPageContainer.tsx
+++ b/src/components/blog/BlogPageContainer.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import NextLink from 'next/link';
-import { Box, Center, Flex, Grid, Pagination, Text, Title } from '@mantine/core';
+import {
+  Box,
+  Center,
+  Flex,
+  Grid,
+  Pagination,
+  Text,
+  Title,
+} from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 
 import { Post } from 'types/types';
@@ -83,11 +91,7 @@ export default function BlogPageContainer() {
             })}
             {/* Pagination */}
             <Flex justify="center" w="100%" mt={16}>
-              <Pagination
-                total={totalPages}
-                value={page}
-                onChange={setPage}
-              />
+              <Pagination total={totalPages} value={page} onChange={setPage} />
             </Flex>
           </Grid>
           {posts.length < 1 && (

--- a/src/components/common/CustomLoader.tsx
+++ b/src/components/common/CustomLoader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Loader, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 
 type Props = {
   loadingText?: string;
@@ -7,9 +7,135 @@ type Props = {
 
 export const CustomLoader = ({ loadingText }: Props) => {
   return (
-    <Flex direction="column" align="center">
-      <Loader size="lg" />
-      <Text fz="lg">{loadingText || 'Loading...'}</Text>
-    </Flex>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '70vh',
+      }}
+    >
+      <svg
+        width="120"
+        height="120"
+        viewBox="0 0 120 120"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <style>{`
+          @keyframes runLeftArm {
+            0%, 100% { transform: rotate(30deg); }
+            50% { transform: rotate(-30deg); }
+          }
+          @keyframes runRightArm {
+            0%, 100% { transform: rotate(-30deg); }
+            50% { transform: rotate(30deg); }
+          }
+          @keyframes runLeftLeg {
+            0%, 100% { transform: rotate(-30deg); }
+            50% { transform: rotate(30deg); }
+          }
+          @keyframes runRightLeg {
+            0%, 100% { transform: rotate(30deg); }
+            50% { transform: rotate(-30deg); }
+          }
+          @keyframes bounce {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-4px); }
+          }
+          .runner-body {
+            animation: bounce 0.35s ease-in-out infinite;
+          }
+          .left-arm {
+            transform-origin: 60px 52px;
+            animation: runLeftArm 0.35s ease-in-out infinite;
+          }
+          .right-arm {
+            transform-origin: 60px 52px;
+            animation: runRightArm 0.35s ease-in-out infinite;
+          }
+          .left-leg {
+            transform-origin: 60px 75px;
+            animation: runLeftLeg 0.35s ease-in-out infinite;
+          }
+          .right-leg {
+            transform-origin: 60px 75px;
+            animation: runRightLeg 0.35s ease-in-out infinite;
+          }
+        `}</style>
+
+        <g className="runner-body">
+          {/* Head */}
+          <circle
+            cx="60"
+            cy="30"
+            r="10"
+            fill="none"
+            stroke="#6c573e"
+            strokeWidth="3"
+          />
+          {/* Body */}
+          <line
+            x1="60"
+            y1="40"
+            x2="60"
+            y2="75"
+            stroke="#6c573e"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        </g>
+
+        {/* Left arm */}
+        <line
+          className="left-arm"
+          x1="60"
+          y1="52"
+          x2="42"
+          y2="68"
+          stroke="#6c573e"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+        {/* Right arm */}
+        <line
+          className="right-arm"
+          x1="60"
+          y1="52"
+          x2="78"
+          y2="68"
+          stroke="#6c573e"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+
+        {/* Left leg */}
+        <line
+          className="left-leg"
+          x1="60"
+          y1="75"
+          x2="44"
+          y2="100"
+          stroke="#6c573e"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+        {/* Right leg */}
+        <line
+          className="right-leg"
+          x1="60"
+          y1="75"
+          x2="76"
+          y2="100"
+          stroke="#6c573e"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+      </svg>
+
+      <Text fz="lg" mt="md">
+        {loadingText || 'Loading...'}
+      </Text>
+    </div>
   );
 };

--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Flex, Text, useMantineTheme } from '@mantine/core';
+import { useNightMode } from 'context/NightModeContext';
+
+let hasLoadedBefore = false;
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const LoadingScreen = ({ children }: Props) => {
+  const theme = useMantineTheme();
+  const { night } = useNightMode();
+  const skipRef = useRef(hasLoadedBefore);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(!skipRef.current);
+
+  useEffect(() => {
+    if (skipRef.current) return;
+
+    const duration = 2000;
+    const steps = 100;
+    const interval = duration / steps;
+    let current = 0;
+
+    const timer = setInterval(() => {
+      current += 1;
+      setCount(current);
+      if (current >= steps) {
+        clearInterval(timer);
+        hasLoadedBefore = true;
+        setTimeout(() => setLoading(false), 300);
+      }
+    }, interval);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <>
+      <AnimatePresence>
+        {loading && (
+          <motion.div
+            key="loading-screen"
+            initial={{ y: 0 }}
+            exit={{ y: '100vh' }}
+            transition={{ duration: 0.8, ease: [0.76, 0, 0.24, 1] }}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 9999,
+              backgroundColor: night
+                ? theme.colors.dark[7]
+                : theme.colors.myColor[9],
+            }}
+          >
+            <Flex
+              align="center"
+              justify="center"
+              h="100vh"
+              direction="column"
+            >
+              <Text
+                ff="'Red Hat Display', serif"
+                fw={200}
+                c={night ? theme.colors.myColor[0] : theme.colors.myColor[0]}
+                style={{ fontSize: 48, lineHeight: 1 }}
+              >
+                {count}
+              </Text>
+            </Flex>
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {children}
+    </>
+  );
+};

--- a/src/components/skillsBanner/SkillsBannerContainer.tsx
+++ b/src/components/skillsBanner/SkillsBannerContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Title } from '@mantine/core';
+import { Box, Flex, Title } from '@mantine/core';
 import { SkillsBanner } from './SkillsBanner';
 import { RollingButton } from 'components/common/buttons/RollingButton';
 import { HIRE_ME_ROUTE } from 'constants/routeConstants';
@@ -11,10 +11,12 @@ export const SkillsBannerContainer = () => {
         Technical Skills & Tools
       </Title>
       <SkillsBanner />
-      <RollingButton
-        label="Find out more"
-        href={`${HIRE_ME_ROUTE}#experience`}
-      />
+      <Box mt={32}>
+        <RollingButton
+          label="Find out more"
+          href={`${HIRE_ME_ROUTE}#experience`}
+        />
+      </Box>
     </Flex>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 
 import PageContainer from 'layouts/PageContainer';
 import HomepageContainer from 'components/homepage/HomepageContainer';
+import { LoadingScreen } from 'components/common/LoadingScreen';
 import { SITE_NAME } from 'constants/constants';
 import { client } from 'client';
 
@@ -12,9 +13,11 @@ export default function PageIndex() {
         <title>{SITE_NAME} | Home</title>
       </Head>
 
-      <PageContainer maxWidth="1000px">
-        <HomepageContainer />
-      </PageContainer>
+      <LoadingScreen>
+        <PageContainer maxWidth="1000px">
+          <HomepageContainer />
+        </PageContainer>
+      </LoadingScreen>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Add a full-screen loading screen on the homepage with an animated counter (0→100) that slides away on completion, shown only on first visit
- Replace the default Mantine spinner in `CustomLoader` with a custom animated stick-figure runner SVG using CSS keyframe animations
- Add spacing fix for the "Find out more" button in the skills banner
- Minor formatting cleanup in `BlogPageContainer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)